### PR TITLE
Add version display on homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,5 +37,6 @@
       }
     });
   </script>
+  <p class="version">v1.0.0</p>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -91,3 +91,12 @@ button:disabled {
   0% { opacity: 1; }
   100% { opacity: 0; }
 }
+
+.version {
+  position: fixed;
+  bottom: 10px;
+  width: 100%;
+  text-align: center;
+  font-size: 0.8em;
+  color: #cccccc;
+}


### PR DESCRIPTION
## Summary
- display app version at the bottom of the homepage
- style the version footer to stick to the bottom of the viewport

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888c3965c5883329f23f397825857e5